### PR TITLE
Clone impl missing `inner`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,9 @@ impl Clone for Element {
         for child in self.children.iter() {
             elem = elem.append(child.clone());
         }
+        if let Some(inr) = &self.inner {
+            elem.inner = Some(inr.to_owned());
+        }
         elem
     }
 }


### PR DESCRIPTION
Cloning the Element now clones the optional inner string. This change is necessary to capture the text set by the `set_inner(...)` function for cloned Elements.