### PR TITLE
Add `rx` and `ry` attributes

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -547,6 +547,9 @@ pub enum Attribute {
     /// No MDN Documentation available for this attribute
     Rotate,
 
+    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx)
+    Rx,
+
     /// No MDN Documentation available for this attribute
     Slope,
 
@@ -980,6 +983,7 @@ impl ToString for Attribute {
             Restart => "restart",
             Result => "result",
             Rotate => "rotate",
+            Rx => "rx",
             Slope => "slope",
             Spacing => "spacing",
             SpecularConstant => "specularConstant",

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -550,6 +550,9 @@ pub enum Attribute {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx)
     Rx,
 
+    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry)
+    Ry,
+
     /// No MDN Documentation available for this attribute
     Slope,
 
@@ -984,6 +987,7 @@ impl ToString for Attribute {
             Result => "result",
             Rotate => "rotate",
             Rx => "rx",
+            Ry => "ry",
             Slope => "slope",
             Spacing => "spacing",
             SpecularConstant => "specularConstant",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -286,6 +286,7 @@ fn string_to_attribute(string: &str) -> crate::attributes::Attribute {
         "restart" => Restart,
         "result" => Result,
         "rotate" => Rotate,
+        "rx" => Rx,
         "slope" => Slope,
         "spacing" => Spacing,
         "specularConstant" => SpecularConstant,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -287,6 +287,7 @@ fn string_to_attribute(string: &str) -> crate::attributes::Attribute {
         "result" => Result,
         "rotate" => Rotate,
         "rx" => Rx,
+        "ry" => Ry,
         "slope" => Slope,
         "spacing" => Spacing,
         "specularConstant" => SpecularConstant,


### PR DESCRIPTION
Adds the missing attributes that are used to specify a border radius for rectangles and ellipses.