### PR TITLE
Don't use regular expression for validating inner value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["graphics"]
 readme = "./README.md"
 
 [dependencies]
-regex="1"
 roxmltree = { version="0.10.0", optional=true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,10 @@ impl Element {
     }
 
     fn is_allowed_inner(text: &str) -> bool {
-        let regular_expression =
-            regex::Regex::new(r#"[a-zA-Z0-9' \\-_/.!?:;(){}[\\]`~&,"]+"#).unwrap();
-        regular_expression.is_match(text)
+        let allowed_chars = r#"' \-_/.!?:;(){}[]`~&,""#;
+
+        text.chars()
+            .all(|c| c.is_ascii_alphanumeric() || allowed_chars.contains(c))
     }
 
     /// Sets the inner text to a plain string


### PR DESCRIPTION
When `set_inner` is called often, a significant amount of time is spend just compiling this regex over and over again.

The regex could be compiled using something like lazy_static!, but removing it alltogether makes more sense since the actual expression used is so simple.

In my limited profiling, the performance gain from this change is somewhere close to infinite.